### PR TITLE
Final tzx block has 0 millisecond delay

### DIFF
--- a/asmimpl.cpp
+++ b/asmimpl.cpp
@@ -4986,10 +4986,10 @@ void AsmReal::writetzxcode (ostream & out)
 
 	// Write the data.
 
-	tzx::writestandardblockhead (out);
+	tzx::writestandardblockhead (out, 1000);
 	block1.write (out);
 
-	tzx::writestandardblockhead (out);
+	tzx::writestandardblockhead (out, 0);
 	block2.write (out);
 	if (! out)
 		throw ErrorOutput;
@@ -5249,10 +5249,10 @@ void AsmReal::emittzxbas (ostream & out)
 
 	tzx::writefilehead (out);
 
-	tzx::writestandardblockhead (out);
+	tzx::writestandardblockhead (out, 1000);
 	basicheadblock.write (out);
 
-	tzx::writestandardblockhead (out);
+	tzx::writestandardblockhead (out, 1000);
 	basicblock.write (out);
 
 	writetzxcode (out);

--- a/tzx.cpp
+++ b/tzx.cpp
@@ -21,12 +21,11 @@ void tzx::writefilehead (std::ostream & out)
 	out.write (tzxhead, sizeof (tzxhead) );
 }
 
-void tzx::writestandardblockhead (std::ostream & out)
+void tzx::writestandardblockhead (std::ostream & out, address pause)
 {
 	out.put ('\x10'); // Standard speed block.
-	address pause= 1000; // Pause after block in milisecs.
-	out.put (lobyte (pause) );
-	out.put (hibyte (pause) );
+	out.put (lobyte (pause) ); // Pause after block
+	out.put (hibyte (pause) ); // in milisecs.
 }
 
 void tzx::writeturboblockhead (std::ostream & out, size_t len)

--- a/tzx.h
+++ b/tzx.h
@@ -4,6 +4,7 @@
 // tzx.h
 // Revision 9-aug-2005
 
+#include "var.h"
 #include <iostream>
 
 #include <stdlib.h>
@@ -13,7 +14,7 @@ namespace tzx {
 
 void writefilehead (std::ostream & out);
 
-void writestandardblockhead (std::ostream & out);
+void writestandardblockhead (std::ostream & out, address pause);
 
 void writeturboblockhead (std::ostream & out, size_t len);
 


### PR DESCRIPTION
This is consistent with [tap2tzx](https://github.com/dominicjprice/tap2tzx/blob/e89c413ff963d99eb569b89c7f100dcdaad4b554/tap2tzx.c#L95-L98) which I believe was written by Tomaz Kac (based on the copyright at the top of the file), the creator of the tzx standard.

Any questions, let me know! :-)