### PR TITLE
fix for_each compilation error

### DIFF
--- a/module.cpp
+++ b/module.cpp
@@ -9,6 +9,7 @@
 
 #include <fstream>
 #include <stdexcept>
+#include <algorithm>
 
 using std::ifstream;
 using std::endl;


### PR DESCRIPTION
fix error when compiled with gcc version 10.2.1 20210110 (Debian 10.2.1-6) 
module.cpp:890:2: error: ‘for_each’ was not declared in this scope
  890 |  for_each (publicvalue.begin (), publicvalue.end (),
      |  ^~~~~~~~
make[1]: *** [Makefile:420: module.o] Error 1