### PR TITLE
fix UNARY minus behaviour

### DIFF
--- a/parser.yxx
+++ b/parser.yxx
@@ -334,6 +334,8 @@ inline void checkugly (Machine & mach, const Token & tok)
 
 %left '*' '/' TypeMOD '%' TypeSHL TypeSHR "<<" ">>"
 
+%left NEGATE
+
 
 %start pasmo_exp
 
@@ -3224,6 +3226,8 @@ base:
 		{ mach.addcode (OpOr); $$= value_0; }
 	| base .xor.   base %prec TypeXOR
 		{ mach.addcode (OpXor); $$= value_0; }
+        | '-'          base %prec NEGATE
+                {  mach.addcode (OpUnMinus); $$= value_0; }
 	| base "&&"    base
 		{ mach.addcode (OpBoolAnd); $$= value_0; }
 	| base "||"    base


### PR DESCRIPTION
fix evaluation of negative values issue #3

After patches, all seems ok:

ld de,-1+1

% z80dasm a

	org	00100h

	ld de,00000h

-----------
ld de,-10000+38

% pasmo a.asm a

% z80dasm a

org 00100h

ld de,0d916h

-----------

ld de,2*20-1

	org	00100h

	ld de,00027h
-----------------
ld de,-1-1+2+(-2)

	org	00100h

	ld de,0fffeh
------------------
ld de,-20*-1

% z80dasm a

	org	00100h

	ld de,00014h
